### PR TITLE
Fix the repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:reid/mock-stream.git"
+    "url": "git@github.com:reid/mock-utf8-stream.git"
   },
   "keywords": [
     "mock",


### PR DESCRIPTION
I was looking for a `mock-stream` module, ran into yours, tried finding
the source code and noticed that the URL in `package.json` was wrong,
so here's a fix :).
